### PR TITLE
Fixed small error in CardLink styles

### DIFF
--- a/app/ui/components/CardLink/CardLink.tsx
+++ b/app/ui/components/CardLink/CardLink.tsx
@@ -12,9 +12,7 @@ export default function CardLink({
     height = 'h-64',
     bgColor = 'bg-slate-400',
 }: CardLinkProps) {
-    const mdColSpan = 'md:' + colspan;
-
     return (
-        <div className={`sm:col-span-1 ${mdColSpan} ${width} ${height} ${bgColor} rounded-xl`}></div>
+        <div className={`${colspan} ${width} ${height} ${bgColor} rounded-xl`}></div>
     )
 }

--- a/app/ui/components/CardLink/CardLink.tsx
+++ b/app/ui/components/CardLink/CardLink.tsx
@@ -12,7 +12,9 @@ export default function CardLink({
     height = 'h-64',
     bgColor = 'bg-slate-400',
 }: CardLinkProps) {
+    const mdColSpan = 'md:' + colspan;
+
     return (
-        <div className={`${colspan} ${width} ${height} ${bgColor} rounded-xl`}></div>
+        <div className={`sm:col-span-1 ${mdColSpan} ${width} ${height} ${bgColor} rounded-xl`}></div>
     )
 }

--- a/app/ui/components/HomeDashboard/HomeDashboard.tsx
+++ b/app/ui/components/HomeDashboard/HomeDashboard.tsx
@@ -3,7 +3,7 @@ import CardLink from "../CardLink/CardLink";
 export default function HomeDashboard() {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 mt-3">
-            <CardLink colspan="col-span-2" />
+            <CardLink colspan="md:col-span-2" />
             <CardLink />
             <CardLink />
             <CardLink />


### PR DESCRIPTION
An error occurred within HomeDashboard component where the first CardLink component would be passed a col-span prop and cause the grid to malfunction and behave like a 2x3 grid in small media query when passed a col-span prop bigger than 1 rather than the desired 1x5. This was due to the CardLink defaulting to the prop rather than just spanning 1 column. A change was made to accept the media query and the col-span amount in Tailwind CSS syntax in the colspan prop for clarity. In the future, changes should be made to make CardLink a bit more usable by not requiring the media query as it is fairly easy to break right now.

Before:
![Before](https://github.com/user-attachments/assets/646e9cf4-f61b-4600-bbaa-02148545d212)


After:
![After](https://github.com/user-attachments/assets/1b13942d-5852-441d-b582-337341de6558)
