### PR TITLE
Convert bgColor prop to twClassName prop

### DIFF
--- a/app/ui/components/CardLink/CardLink.tsx
+++ b/app/ui/components/CardLink/CardLink.tsx
@@ -2,9 +2,7 @@ import Link from "next/link";
 
 interface CardLinkProps {
     colspan?: string;
-    width?: string;
-    height?: string;
-    bgColor?: string;
+    twClassName?: string;
     imgSrc?: string;
     href?: string;
     title: string;
@@ -12,9 +10,7 @@ interface CardLinkProps {
 
 export default function CardLink({
     colspan = 'col-span-1',
-    width = 'w-full',
-    height = 'h-64',
-    bgColor = 'bg-slate-400',
+    twClassName,
     imgSrc,
     href = '#',
     title
@@ -23,7 +19,7 @@ export default function CardLink({
         <div className={`${colspan}`}>
             <Link href={href}>
             <div
-                    className={`${width} ${height} ${bgColor} rounded-xl overflow-hidden cursor-pointer relative`}
+                    className={`w-full h-64 bg-slate-400 rounded-xl overflow-hidden cursor-pointer relative ${twClassName}`}
                 >
                     <div
                         className="absolute inset-0 transition-transform transform scale-100 hover:scale-110"

--- a/app/ui/components/Hero/Hero.tsx
+++ b/app/ui/components/Hero/Hero.tsx
@@ -5,12 +5,12 @@ import LayoutBand from "../layout/LayoutBand/LayoutBand";
 
 interface HeroProps {
     imgSrc?: string;
-    bgColor?: string;
+    twClassName?: string;
 }
 
 export default function Hero({
     imgSrc,
-    bgColor = 'bg-secondaryColor'
+    twClassName,
 }: HeroProps) {
     const [offsetY, setOffsetY] = useState(0);
 
@@ -26,7 +26,7 @@ export default function Hero({
     return (
         <div className={styles.hero}>
             <div
-                className={`${bgColor}`}
+                className={`bg-secondaryColor ${twClassName}`}
                 style={{
                     transform: `translateY(${offsetY * 0.5}px)`,
                     backgroundImage: `url('${imgSrc}')`


### PR DESCRIPTION
Make the following changes:
- Convert bgColor prop to twClassName prop on Hero and CardLink components and remove width, height props since they all use tailwind className as their base and are all put on the same element
- Keep colspan prop on CardLink as this is separate from the core styling of the component and used to determine where in the grid the card is placed