### PR TITLE
Add clsx to project and consume in Hero and CardLink

### DIFF
--- a/app/ui/components/CardLink/CardLink.tsx
+++ b/app/ui/components/CardLink/CardLink.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
+import clsx from "clsx";
 
 interface CardLinkProps {
     colspan?: string;
-    twClassName?: string;
+    className?: string;
     imgSrc?: string;
     href?: string;
     ariaLabel?: string;
@@ -11,7 +12,7 @@ interface CardLinkProps {
 
 export default function CardLink({
     colspan = 'col-span-1',
-    twClassName,
+    className,
     imgSrc,
     href = '#',
     ariaLabel,
@@ -20,8 +21,11 @@ export default function CardLink({
     return (
         <div className={`${colspan}`}>
             <Link href={href} aria-label={ariaLabel}>
-            <div
-                    className={`w-full h-64 bg-slate-400 rounded-xl overflow-hidden cursor-pointer relative ${twClassName}`}
+                <div
+                    className={clsx(
+                        'w-full h-64 bg-slate-400 rounded-xl overflow-hidden cursor-pointer relative',
+                        className,
+                    )}
                 >
                     <div
                         className="absolute inset-0 transition-transform transform scale-100 hover:scale-110"

--- a/app/ui/components/Hero/Hero.tsx
+++ b/app/ui/components/Hero/Hero.tsx
@@ -1,18 +1,19 @@
 'use client';
 import { useEffect, useState } from "react";
+import clsx from "clsx";
 import styles from './Hero.module.scss';
 import LayoutBand from "../layout/LayoutBand/LayoutBand";
 
 interface HeroProps {
     imgSrc?: string;
     title: string;
-    twClassName?: string;
+    className?: string;
 }
 
 export default function Hero({
     imgSrc,
     title,
-    twClassName,
+    className,
 }: HeroProps) {
     const [offsetY, setOffsetY] = useState(0);
 
@@ -28,7 +29,10 @@ export default function Hero({
     return (
         <div className={styles.hero}>
             <div
-                className={`bg-secondaryColor ${twClassName}`}
+                className={clsx(
+                    'bg-secondaryColor',
+                    className,
+                )}
                 style={{
                     transform: `translateY(${offsetY * 0.5}px)`,
                     backgroundImage: `url('${imgSrc}')`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/postgres": "^0.10.0",
+    "clsx": "^2.1.1",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@vercel/postgres':
         specifier: ^0.10.0
         version: 0.10.0
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 15.1.0
         version: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.82.0)
@@ -648,6 +651,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2419,6 +2426,8 @@ snapshots:
       readdirp: 4.0.2
 
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
Make the following changes:
- Add clsx to assist in custom className styles on components with existing className styles
- Consume in Hero and CardLink components, replacing "twClassName" props in both