### PR TITLE
Create PageLink component

### DIFF
--- a/app/page-in-development/page.tsx
+++ b/app/page-in-development/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 import LayoutBand from "../ui/components/layout/LayoutBand/LayoutBand"
-import Link from "next/link"
+import PageLink from "../ui/components/PageLink/PageLink"
 
 export const metadata: Metadata = {
     title: 'Page In Development',
@@ -11,7 +11,7 @@ export default function PageInDevelopment() {
         <LayoutBand>
             <h1>Looks like this page isn&#39;t done yet!</h1>
             <p>We are still hard at work developing this page. Please try again later!</p>
-            <Link href='/' className="block w-fit"><p className="rounded bg-accent1 w-fit px-4 mx-2 my-4 hover:bg-slate-200 text-white hover:text-accent1 transition duration 150">Return Home</p></Link>
+            <PageLink href='/' className="mx-2" button>Return Home</PageLink>
         </LayoutBand>
     )
 }

--- a/app/ui/components/PageLink/PageLink.tsx
+++ b/app/ui/components/PageLink/PageLink.tsx
@@ -1,0 +1,30 @@
+import Link, { LinkProps } from "next/link";
+import clsx from "clsx";
+
+interface PageLinkProps extends LinkProps {
+    children?: React.ReactNode;
+    button?: boolean;
+    className?: string;
+}
+
+export default function PageLink({
+    children, 
+    button = false, 
+    className, 
+    ...rest
+}: PageLinkProps) {
+    return (
+        <Link 
+            className={clsx(
+                'block w-fit',
+                button 
+                    ? 'rounded bg-accent1 px-4 py-2.5 my-4 hover:bg-slate-200 text-white hover:text-accent1 transition duration 150' 
+                    : 'text-accent1 mt-1 hover:underline',
+                className
+            )}
+            {...rest}
+        >
+            {children}
+        </Link>
+    )
+}

--- a/app/ui/components/account/LoginForm/LoginForm.tsx
+++ b/app/ui/components/account/LoginForm/LoginForm.tsx
@@ -3,7 +3,7 @@
 import { useActionState } from "react"
 import Form from "@/app/ui/components/Form/Form"
 import Separator from "../../layout/Separator/Separator";
-import Link from "next/link";
+import PageLink from "../../PageLink/PageLink";
 import { authenticateUser, AuthState } from "@/app/lib/actions/auth";
 
 export default function LoginForm() {
@@ -74,7 +74,7 @@ export default function LoginForm() {
                     >
                         Login
                     </button>
-                    <Link className="text-accent1 block w-fit mx-auto mt-1 hover:underline" href='/account/create-account'>Don&#39;t have an account? Create one here!</Link>
+                    <PageLink href='/account/create-account' className="mx-auto">Don&#39;t have an account? Create one here!</PageLink>
                 </fieldset>
             </Form>
         </>


### PR DESCRIPTION
The PageLink component is intended to modularize the page links around the VMC website and make it easier to create a page link that is styled according to VMC website theming. The PageLink component also includes a button prop to control whether the link is styled as a button or like a normal text link. The button also extends normal LinkProps from Next.js. 

Make the following changes:
- Create PageLink component
- Move logic from existing page links on LoginForm.tsx and /page-in-development/page.tsx to new PageLink component and consume PageLink in their respective places