### PR TITLE
Create form for CreateAccountForm component and early createUser logic

### DIFF
--- a/app/account/create-account/page.tsx
+++ b/app/account/create-account/page.tsx
@@ -9,7 +9,6 @@ export const metadata: Metadata = {
 export default function CreateAccount() {
     return (
         <LayoutBand>
-            <h1>This is the Create Account Page!</h1>
             <CreateAccountForm></CreateAccountForm>
         </LayoutBand>
     )

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -126,7 +126,8 @@ export async function createUser(prevState: AuthState, formData: FormData) {
         };
     }
 
-    const { first_name, middle_name, last_name, email, password, phone } = validatedFields.data;
+    // const { first_name, middle_name, last_name, email, password, phone } = validatedFields.data;
+    const { email } = validatedFields.data; // Temporary code while other variables are not in use
 
     try {
         const duplicateEmail = await sql`SELECT COUNT(*) FROM dev.test_user WHERE email = ${email}`;

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -39,7 +39,10 @@ export type AuthState = {
         password?: string[];
         phone?: string[];
     };
-    message: string;
+    message: {
+        status: string;
+        text: string;
+    };
 }
 
 const AuthenticateUser = AccountFormSchema.omit({
@@ -59,7 +62,10 @@ export async function authenticateUser(prevState: AuthState, formData: FormData)
     if (!validatedFields.success) {
         return {
             errors: validatedFields.error.flatten().fieldErrors,
-            message: 'Missing or Invalid Fields. Failed to Login.'
+            message: {
+                status: 'error',
+                text: 'Missing or Invalid Fields. Failed to Login.',
+            },
         };
     }
 
@@ -68,14 +74,27 @@ export async function authenticateUser(prevState: AuthState, formData: FormData)
     try {
         const user = await sql<User>`SELECT * FROM dev.test_user WHERE email=${email} AND password=${password}`;
         if (user.rows[0]) {
-            return { message: `Welcome, ${user.rows[0]['first_name']}!`};
+            return {
+                message: {
+                    status: 'success',
+                    text: `Welcome, ${user.rows[0]['first_name']}!`
+                }
+            };
         } else {
-            return { message: 'The email and/or password you entered was invalid. Please try again or create an account.'};
+            return {
+                message: {
+                    status: 'error',
+                    text: 'The email and/or password you entered was invalid. Please try again or create an account.',
+                }
+            };
         }
     } catch (error) {
         console.log(error);
         return {
-            message: 'Database Error: Failed to Login.'
+            message: {
+                status: 'error',
+                text: 'Database Error: Failed to Login.'
+            }
         };
     }
     
@@ -83,6 +102,57 @@ export async function authenticateUser(prevState: AuthState, formData: FormData)
     redirect('/');
 }
 
-export async function createUser() {
+const CreateUser = AccountFormSchema.omit({
+    user_id: true,
+})
 
+export async function createUser(prevState: AuthState, formData: FormData) {
+    const validatedFields = CreateUser.safeParse({
+        first_name: formData.get('first_name'),
+        middle_name: formData.get('middle_name'),
+        last_name: formData.get('last_name'),
+        email: formData.get('email'),
+        password: formData.get('password'),
+        phone: formData.get('phone'),
+    });
+
+    if (!validatedFields.success) {
+        return {
+            errors: validatedFields.error.flatten().fieldErrors,
+            message: {
+                status: 'error',
+                text: 'Missing or Invalid Fields. Failed to create account.'
+            }
+        };
+    }
+
+    const { first_name, middle_name, last_name, email, password, phone } = validatedFields.data;
+
+    try {
+        const duplicateEmail = await sql`SELECT COUNT(*) FROM dev.test_user WHERE email = ${email}`;
+        console.log(duplicateEmail);
+        if (duplicateEmail.rows[0].count > 0) {
+            return {
+                message: {
+                    status: 'error',
+                    text: 'The email address submitted is already associated with another account. Please use a different email address.'
+                }
+            }
+        }
+    } catch (error) {
+        console.log(error);
+        return {
+            message: {
+                status: 'error',
+                text: 'Database error. Failed to create account.'
+            }
+        }
+    }
+
+    return {
+        message: {
+            status: 'success',
+            text: 'Account Creation Initiated'
+        }
+    }
 }

--- a/app/ui/components/account/CreateAccountForm/CreateAccountForm.tsx
+++ b/app/ui/components/account/CreateAccountForm/CreateAccountForm.tsx
@@ -1,26 +1,152 @@
 'use client';
 
-// import { useActionState } from "react"
+import { useActionState } from "react"
 import Form from "@/app/ui/components/vmc-form/Form/Form"
-// import { createUser, AuthState } from "@/app/lib/actions/auth"
+import OutlineFieldset from "../../vmc-form/OutlineFieldset/OutlineFieldset";
+import OutlineFieldsetLegend from "../../vmc-form/OutlineFieldsetLegend/OutlineFieldsetLegend";
+import InputContainer from "../../vmc-form/InputContainer/InputContainer";
+import OutlineInput from "../../vmc-form/Input/Input";
+import FormButton from "../../vmc-form/FormButton/FormButton";
+import StatusMessage from "../../vmc-form/StatusMessage/StatusMessage";
+import Separator from "../../layout/Separator/Separator";
+import PageLink from "../../PageLink/PageLink";
+import { createUser, AuthState } from "@/app/lib/actions/auth";
 
 export default function CreateAccountForm() {
-    // const initialState: AuthState = { message: '', errors: {}}
-    // const [state, formAction, isPending] = useActionState(
-    //     createUser,
-    //     initialState,
-    // );
+    const initialState: AuthState = { message: {status: 'none', text: ''}, errors: {}}
+    const [state, formAction, isPending] = useActionState(
+        createUser,
+        initialState,
+    );
 
     return (
-        <Form action='/'>
-            {/* <div id="form-error" aria-live="polite" aria-atomic="true">
-                {state.message && (
-                    <p className="mt-2 text-sm text-red-500" key="Form Error">
-                        {state.message}
-                    </p>
-                )}
-            </div> */}
-            <p>This is the Create Account form!</p>
-        </Form>
+        <>
+            <Separator size="sm" />
+            <Form action={formAction}>
+                <OutlineFieldset>
+                    <OutlineFieldsetLegend>Create an Account with Valley Music Club</OutlineFieldsetLegend>
+                    <div id="form-error" aria-live="polite" aria-atomic="true">
+                        {state.message.text && (
+                            <StatusMessage status={state.message.status} key={state.message.text}>
+                                {state.message.text}
+                            </StatusMessage>
+                        )}
+                    </div>
+                    <InputContainer>
+                        <label htmlFor="first_name">First Name*</label>
+                        <OutlineInput 
+                            id="first_name"
+                            name="first_name"
+                            type="first_name"
+                            placeholder="John"
+                            aria-describedby="first_name-error"
+                        />
+                        <div id="first_name-error" aria-live="polite" aria-atomic="true">
+                            {state.errors?.first_name &&
+                                state.errors.first_name.map((error: string) => (
+                                    <StatusMessage status="error" key={error}>
+                                        {error}
+                                    </StatusMessage>
+                                ))
+                            }
+                        </div>
+                    </InputContainer>
+                    <InputContainer>
+                        <label htmlFor="middle_name">Middle Name</label>
+                        <OutlineInput 
+                            id="middle_name"
+                            name="middle_name"
+                            type="middle_name"
+                            aria-describedby="middle_name-error"
+                        />
+                        <div id="email-error" aria-live="polite" aria-atomic="true">
+                            {state.errors?.middle_name &&
+                                state.errors.middle_name.map((error: string) => (
+                                    <StatusMessage status="error" key={error}>
+                                        {error}
+                                    </StatusMessage>
+                                ))
+                            }
+                        </div>
+                    </InputContainer>
+                    <InputContainer>
+                        <label htmlFor="last_name">Last Name*</label>
+                        <OutlineInput 
+                            id="last_name"
+                            name="last_name"
+                            type="last_name"
+                            placeholder="Smith"
+                            aria-describedby="last_name-error"
+                        />
+                        <div id="last_name-error" aria-live="polite" aria-atomic="true">
+                            {state.errors?.last_name &&
+                                state.errors.last_name.map((error: string) => (
+                                    <StatusMessage status="error" key={error}>
+                                        {error}
+                                    </StatusMessage>
+                                ))
+                            }
+                        </div>
+                    </InputContainer>
+                    <InputContainer>
+                        <label htmlFor="email">Email*</label>
+                        <OutlineInput 
+                            id="email"
+                            name="email"
+                            type="email"
+                            placeholder="johnsmith@example.com"
+                            aria-describedby="email-error"
+                        />
+                        <div id="email-error" aria-live="polite" aria-atomic="true">
+                            {state.errors?.email &&
+                                state.errors.email.map((error: string) => (
+                                    <StatusMessage status="error" key={error}>
+                                        {error}
+                                    </StatusMessage>
+                                ))
+                            }
+                        </div>
+                    </InputContainer>
+                    <InputContainer>
+                        <label htmlFor="password">Password*</label>
+                        <OutlineInput 
+                            type="password"
+                            id="password"
+                            name="password"
+                            aria-describedby="email-error"
+                        />
+                        <div id="password-error" aria-live="polite" aria-atomic="true">
+                            {state.errors?.password &&
+                                state.errors.password.map((error: string) => (
+                                    <StatusMessage status="error" key={error}>
+                                        {error}
+                                    </StatusMessage>
+                                ))
+                            }
+                        </div>
+                    </InputContainer>
+                    <InputContainer>
+                        <label htmlFor="phone">Phone Number</label>
+                        <OutlineInput 
+                            type="phone"
+                            id="phone"
+                            name="phone"
+                            aria-describedby="phone-error"
+                        />
+                        <div id="phone-error" aria-live="polite" aria-atomic="true">
+                            {state.errors?.phone &&
+                                state.errors.phone.map((error: string) => (
+                                    <StatusMessage status="error" key={error}>
+                                        {error}
+                                    </StatusMessage>
+                                ))
+                            }
+                        </div>
+                    </InputContainer>
+                    <FormButton type="submit" disabled={isPending}>Create Account</FormButton>
+                    <PageLink href='/account/login' className="mx-auto">Already have an account? Login here!</PageLink>
+                </OutlineFieldset>
+            </Form>
+        </>
     )
 }

--- a/app/ui/components/account/LoginForm/LoginForm.tsx
+++ b/app/ui/components/account/LoginForm/LoginForm.tsx
@@ -13,7 +13,7 @@ import PageLink from "../../PageLink/PageLink";
 import { authenticateUser, AuthState } from "@/app/lib/actions/auth";
 
 export default function LoginForm() {
-    const initialState: AuthState = { message: '', errors: {}}
+    const initialState: AuthState = { message: {status: 'none', text: ''}, errors: {}}
     const [state, formAction, isPending] = useActionState(
         authenticateUser,
         initialState,
@@ -26,9 +26,9 @@ export default function LoginForm() {
                 <OutlineFieldset>
                     <OutlineFieldsetLegend>Login to Valley Music Club</OutlineFieldsetLegend>
                     <div id="form-error" aria-live="polite" aria-atomic="true">
-                        {state.message && (
-                            <StatusMessage status="error" key={state.message}>
-                                {state.message}
+                        {state.message.text && (
+                            <StatusMessage status={state.message.status} key={state.message.text}>
+                                {state.message.text}
                             </StatusMessage>
                         )}
                     </div>

--- a/app/ui/components/vmc-form/StatusMessage/StatusMessage.tsx
+++ b/app/ui/components/vmc-form/StatusMessage/StatusMessage.tsx
@@ -2,7 +2,13 @@ import clsx from "clsx"
 
 interface StatusMessageProps extends React.HTMLAttributes<HTMLParagraphElement> {
     children?: React.ReactNode;
-    status: 'success' | 'error';
+    status: 'success' | 'error' | 'warning' | string;
+}
+
+const statusClasses: Record<string, string> = {
+    success: 'text-green-500',
+    error: 'text-red-500',
+    warning: 'text-yellow-500',
 }
 
 export default function StatusMessage({
@@ -16,8 +22,7 @@ export default function StatusMessage({
             {...rest}
             className={clsx(
                 'p-0 my-1 text-sm',
-                status === 'error' && 'text-red-500',
-                status === 'success' && 'text-green-500',
+                statusClasses[status] || 'text-white',
                 className
             )}
         >


### PR DESCRIPTION
Make the following changes:
- Use new components to create form for CreateAccountForm component
- Remove h1 tag from create-account/page.tsx
- Adjust StatusMessage component to accept 'warning' as well as any string for status prop due to signature constraints on useActionState hook
- Change message type on AuthType in auth.ts from string to object with status and text as properties to assist in displaying custom error messages with StatusMessage component
- Adjust consumption of state.message in LoginForm and CreateAccountForm accordingly
- Create basic logic for createUser in auth.ts (not fully functional yet)