### PR TITLE
Update authentication logic to correctly refresh AuthContext 

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -9,6 +9,7 @@ export default function AccountHome() {
     return (
         <LayoutBand>
             <h1>Welcome to the Account Homepage!</h1>
+            <p>This page is still in development. Please check back later for more features!</p>
         </LayoutBand>
     )
 }

--- a/app/create-account/layout.tsx
+++ b/app/create-account/layout.tsx
@@ -1,0 +1,10 @@
+import { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+    title: 'Create an Account',
+};
+
+export default function CreateAccountLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}

--- a/app/create-account/page.tsx
+++ b/app/create-account/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Metadata } from "next"
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
@@ -18,7 +19,7 @@ export default function CreateAccount() {
             router.push('/account');
         }
     }, [isAuthenticated, router]);
-    
+
     return (
         <LayoutBand>
             <CreateAccountForm></CreateAccountForm>

--- a/app/create-account/page.tsx
+++ b/app/create-account/page.tsx
@@ -1,14 +1,9 @@
 'use client';
-import { Metadata } from "next"
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "../context/AuthContext"
 import { LayoutBand } from "blisskit-ui"
 import CreateAccountForm from "@/app/ui/components/account/CreateAccountForm/CreateAccountForm"
-
-export const metadata: Metadata = {
-    title: 'Create an Account',
-}
 
 export default function CreateAccount() {
     const { isAuthenticated } = useAuth();

--- a/app/create-account/page.tsx
+++ b/app/create-account/page.tsx
@@ -1,4 +1,7 @@
 import { Metadata } from "next"
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "../context/AuthContext"
 import { LayoutBand } from "blisskit-ui"
 import CreateAccountForm from "@/app/ui/components/account/CreateAccountForm/CreateAccountForm"
 
@@ -7,6 +10,15 @@ export const metadata: Metadata = {
 }
 
 export default function CreateAccount() {
+    const { isAuthenticated } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (isAuthenticated) {
+            router.push('/account');
+        }
+    }, [isAuthenticated, router]);
+    
     return (
         <LayoutBand>
             <CreateAccountForm></CreateAccountForm>

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -18,7 +18,7 @@ const AccountFormSchema = z.object({
         .min(1, 'Please provide a first name'),
     middle_name: z.string({
         invalid_type_error: 'Please provide a valid middle name',
-    }).optional(),
+    }).optional().transform(value => value?.trim() === '' ? null : value),
     last_name: z.string({
         invalid_type_error: 'Please provide a valid last name',
     })
@@ -33,6 +33,7 @@ const AccountFormSchema = z.object({
           "Please provide a valid phone number"
         )
         .optional()
+        .transform(value => value?.trim() === '' ? null : value)
 });
 
 export type AuthState = {
@@ -124,9 +125,6 @@ export async function authenticateUser(prevState: AuthState, formData: FormData)
             text: 'Successfully logged in!',
         },
     };
-    
-    revalidatePath('/account');
-    redirect('/account');
 }
 
 const CreateUser = AccountFormSchema.omit({
@@ -157,7 +155,7 @@ export async function createUser(prevState: AuthState, formData: FormData) {
 
     try {
         const duplicateEmail = await sql`SELECT COUNT(*) FROM dev.test_user WHERE email = ${email}`;
-        const duplicatePhone = await sql`SELECT COUNT(*) FROM dev.test_user WHERE phone = ${phone}`;
+        const duplicatePhone = phone ? await sql`SELECT COUNT(*) FROM dev.test_user WHERE phone = ${phone}` : { rows: [{ count: 0 }] };
         
         if (duplicateEmail.rows[0].count > 0) {
             return {
@@ -208,9 +206,6 @@ export async function createUser(prevState: AuthState, formData: FormData) {
             text: 'Account Created Successfully!',
         }
     }
-
-    revalidatePath('/account');
-    redirect('/account');
 }
 
 export async function logoutUser() {

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -117,6 +117,13 @@ export async function authenticateUser(prevState: AuthState, formData: FormData)
             }
         };
     }
+
+    return {
+        message: {
+            status: 'success',
+            text: 'Successfully logged in!',
+        },
+    };
     
     revalidatePath('/account');
     redirect('/account');
@@ -185,16 +192,6 @@ export async function createUser(prevState: AuthState, formData: FormData) {
             path: '/',
             secure: process.env.NODE_ENV === 'production',
         })
-
-        revalidatePath('/account');
-        redirect('/account');
-
-        return {
-            message: {
-                status: 'success',
-                text: 'Account Created Successfully!',
-            }
-        }
     } catch (error) {
         console.log(error);
         return {
@@ -204,6 +201,16 @@ export async function createUser(prevState: AuthState, formData: FormData) {
             }
         }
     }
+
+    return {
+        message: {
+            status: 'success',
+            text: 'Account Created Successfully!',
+        }
+    }
+
+    revalidatePath('/account');
+    redirect('/account');
 }
 
 export async function logoutUser() {

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,10 @@
+import { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+    title: 'Login',
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,14 +1,9 @@
 'use client';
-import { Metadata } from "next"
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "../context/AuthContext"
 import { LayoutBand } from "blisskit-ui"
 import LoginForm from "@/app/ui/components/account/LoginForm/LoginForm"
-
-export const metadata: Metadata = {
-    title: 'Login',
-}
 
 export default function Login() {
     const { isAuthenticated } = useAuth();

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,7 @@
 import { Metadata } from "next"
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "../context/AuthContext"
 import { LayoutBand } from "blisskit-ui"
 import LoginForm from "@/app/ui/components/account/LoginForm/LoginForm"
 
@@ -7,6 +10,15 @@ export const metadata: Metadata = {
 }
 
 export default function Login() {
+    const { isAuthenticated } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (isAuthenticated) {
+            router.push('/account');
+        }
+    }, [isAuthenticated, router]);
+    
     return (
         <LayoutBand>
             <LoginForm></LoginForm>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Metadata } from "next"
 import { useEffect } from "react"
 import { useRouter } from "next/navigation"
@@ -18,7 +19,7 @@ export default function Login() {
             router.push('/account');
         }
     }, [isAuthenticated, router]);
-    
+
     return (
         <LayoutBand>
             <LoginForm></LoginForm>

--- a/app/ui/components/account/CreateAccountForm/CreateAccountForm.tsx
+++ b/app/ui/components/account/CreateAccountForm/CreateAccountForm.tsx
@@ -158,7 +158,7 @@ export default function CreateAccountForm() {
                         </div>
                     </InputContainer>
                     <FormButton type="submit" disabled={isPending}>Create Account</FormButton>
-                    <PageLink href='/account/login' className="mx-auto">Already have an account? Login here!</PageLink>
+                    <PageLink href='/login' className="mx-auto">Already have an account? Login here!</PageLink>
                 </OutlineFieldset>
             </Form>
         </>

--- a/app/ui/components/account/CreateAccountForm/CreateAccountForm.tsx
+++ b/app/ui/components/account/CreateAccountForm/CreateAccountForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState } from "react"
+import { useActionState, useEffect } from "react"
 import { Separator } from "blisskit-ui";
 import { createUser, AuthState } from "@/app/lib/actions/auth";
 import Form from "@/app/ui/components/vmc-form/Form/Form"
@@ -11,6 +11,8 @@ import OutlineInput from "../../vmc-form/Input/Input";
 import FormButton from "../../vmc-form/FormButton/FormButton";
 import StatusMessage from "../../vmc-form/StatusMessage/StatusMessage";
 import PageLink from "../../PageLink/PageLink";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/app/context/AuthContext";
 
 export default function CreateAccountForm() {
     const initialState: AuthState = { message: {status: 'none', text: ''}, errors: {}}
@@ -18,6 +20,17 @@ export default function CreateAccountForm() {
         createUser,
         initialState,
     );
+    const { refreshAuth } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (state.message.status === 'success') {
+            console.log('Account created successfully, refreshing auth...');
+            refreshAuth();
+
+            router.push('/account');
+        }
+    }, [state.message.status, refreshAuth, router])
 
     return (
         <>

--- a/app/ui/components/account/LoginForm/LoginForm.tsx
+++ b/app/ui/components/account/LoginForm/LoginForm.tsx
@@ -83,7 +83,7 @@ export default function LoginForm() {
                         </div>
                     </InputContainer>
                     <FormButton type="submit" disabled={isPending}>Login</FormButton>
-                    <PageLink href='/account/create-account' className="mx-auto">Don&#39;t have an account? Create one here!</PageLink>
+                    <PageLink href='/create-account' className="mx-auto">Don&#39;t have an account? Create one here!</PageLink>
                 </OutlineFieldset>
             </Form>
         </>

--- a/app/ui/components/account/LoginForm/LoginForm.tsx
+++ b/app/ui/components/account/LoginForm/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState } from "react"
+import { useActionState, useEffect } from "react"
 import { Separator } from "blisskit-ui";
 import { authenticateUser, AuthState } from "@/app/lib/actions/auth";
 import Form from "@/app/ui/components/vmc-form/Form/Form"
@@ -11,6 +11,8 @@ import OutlineInput from "../../vmc-form/Input/Input";
 import FormButton from "../../vmc-form/FormButton/FormButton";
 import StatusMessage from "../../vmc-form/StatusMessage/StatusMessage";
 import PageLink from "../../PageLink/PageLink";
+import { useAuth } from "@/app/context/AuthContext";
+import { useRouter } from "next/navigation";
 
 export default function LoginForm() {
     const initialState: AuthState = { message: {status: 'none', text: ''}, errors: {}}
@@ -18,6 +20,17 @@ export default function LoginForm() {
         authenticateUser,
         initialState,
     );
+    const { refreshAuth } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (state.message.status === 'success') {
+            console.log('Logged in successfully, refreshing auth...');
+            refreshAuth();
+
+            router.push('/account');
+        }
+    }, [state.message.status, refreshAuth, router])
 
     return (
         <>

--- a/app/ui/components/body/NavBar/NavBar.tsx
+++ b/app/ui/components/body/NavBar/NavBar.tsx
@@ -66,6 +66,13 @@ export default function NavBar() {
                         </li>
                     )
                 })}
+                {isAuthenticated && 
+                    <li key='account-home' className='hover:text-white cursor-pointer transition duration 150'>
+                        <Link href='/account' aria-label='View your account dashboard.' onClick={handleLinkClick}>
+                            Account Home
+                        </Link>
+                    </li>
+                }
                 {isAuthenticated ? (
                     <li key='logout' className='hover:text-white cursor-pointer transition duration 150'>
                         <Link href='/logout' aria-label='Logout and end user session.' onClick={() => {handleLinkClick(); refreshAuth();}}>


### PR DESCRIPTION
Make the following changes:
- Update createUser/authenticateUser to return an AuthState object in all paths instead of redirecting, move redirection logic to LoginForm and CreateAccountForm
- Update CreateAccountForm and LoginForm to use refreshAuth to refresh the AuthContext correctly after a successful account creation / login
- Redirect users to /account when attempting to access /login and /create-account routes while authenticated
- Add Account Home link to NavBar when authenticated